### PR TITLE
Fix github action trigger for main-branch

### DIFF
--- a/.github/workflows/app-deployment.yml
+++ b/.github/workflows/app-deployment.yml
@@ -3,11 +3,7 @@ name: Deploy iOS and Android App (JS only)
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ development ]
-    paths:
-    - 'app/**'
-  pull_request:
-    branches: [ main ]
+    branches: [ development, main ]
     paths:
     - 'app/**'
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,11 +6,7 @@ name: Defikarte-Backend
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ development ]
-    paths:
-    - 'backend/**'
-  pull_request:
-    branches: [ main ]
+    branches: [ development, main ]
     paths:
     - 'backend/**'
 


### PR DESCRIPTION
Change the trigger for the github action, so it will also execute if an push / changes comes to the main branch (which is protected)