### PR TITLE
Revert "Change tile url for osm overlay"

### DIFF
--- a/app/defikarte/package-lock.json
+++ b/app/defikarte/package-lock.json
@@ -7783,8 +7783,8 @@
       }
     },
     "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
       "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
     },
     "xpipe": {

--- a/app/defikarte/src/components/Map.js
+++ b/app/defikarte/src/components/Map.js
@@ -134,7 +134,7 @@ const Map = ({ initCoords, mapRef, defibrillators, defibrillatorsLoading, isCrea
   }
 
   const tileOverlay = isTileOverlayActive ? <UrlTile
-    urlTemplate='https://tile.osm.ch/osm-swiss-style/{z}/{x}/{y}.png'
+    urlTemplate='http://c.tile.openstreetmap.org/{z}/{x}/{y}.png'
     maximumZ={19}
     flipY={false}
   /> : null;


### PR DESCRIPTION
Reverts chnuessli/defikarte.ch-app#111

@elektrolytmangel can you change the url for the defi detail page also? there seems to be the old url.