### PR TITLE
Update Build Pipeline for no wait

### DIFF
--- a/.github/workflows/app-deployment.yml
+++ b/.github/workflows/app-deployment.yml
@@ -38,4 +38,4 @@ jobs:
         run: npm ci
       - name: Build on EAS
         working-directory: ${{ env.APP_SRC_PATH }}
-        run: eas build --profile ${{ env.RELEASE_PROFILE }} --platform all --non-interactive
+        run: eas build --profile ${{ env.RELEASE_PROFILE }} --platform all --non-interactive --no-wait


### PR DESCRIPTION
If the no-wait-flag is set, the pipeline does not need to wait for eas build end. This decreases the github action time a lot