### PR TITLE
Fix swisstopo address search

### DIFF
--- a/backend/DefikarteBackend/Configuration/ServiceConfiguration.cs
+++ b/backend/DefikarteBackend/Configuration/ServiceConfiguration.cs
@@ -27,6 +27,8 @@ namespace DefikarteBackend.Configuration
 
         public string AddressSearchUrl { get; private set; } = string.Empty;
 
+        public string MaptilerApiKey { get; private set; } = string.Empty;
+
         public static ServiceConfiguration Initialize(IConfigurationRoot configuration)
         {
             return new ServiceConfiguration
@@ -42,6 +44,7 @@ namespace DefikarteBackend.Configuration
                 BlobStorageBlobNameLocalV2 = configuration.GetValue<string>("BLOB_STORAGE_BLOB_NAME_LOCAL_V2") ?? string.Empty,
                 BlobStorageSwissBoundariesName = configuration.GetValue<string>("BLOB_STORAGE_SWISSBOUNDARIES") ?? string.Empty,
                 AddressSearchUrl = configuration.GetValue<string>("ADDRESS_SEARCH_URL") ?? string.Empty,
+                MaptilerApiKey = configuration.GetValue<string>("MAPTILER_API_KEY") ?? string.Empty,
             };
         }
     }

--- a/backend/DefikarteBackend/Interfaces/IServiceConfiguration.cs
+++ b/backend/DefikarteBackend/Interfaces/IServiceConfiguration.cs
@@ -23,5 +23,7 @@
         string OverpassApiUrl { get; }
 
         string AddressSearchUrl { get; }
+
+        string MaptilerApiKey { get; }
     }
 }

--- a/backend/DefikarteBackend/Model/FeatureCollection.cs
+++ b/backend/DefikarteBackend/Model/FeatureCollection.cs
@@ -9,6 +9,13 @@ namespace DefikarteBackend.Model
         public List<Feature> Features { get; set; } = [];
     }
 
+    public class FeatureCollection<TFeature>
+    {
+        public string Type { get; set; } = "FeatureCollection";
+
+        public List<TFeature> Features { get; set; } = [];
+    }
+
     public class Feature
     {
         public string Type { get; set; } = "Feature";
@@ -20,7 +27,7 @@ namespace DefikarteBackend.Model
 
         public PointGeometry Geometry { get; set; } = new PointGeometry();
 
-        public Dictionary<string, string> Properties { get; set; } = [];
+        public virtual Dictionary<string, string> Properties { get; set; } = [];
     }
 
     public class PointGeometry

--- a/backend/DefikarteBackend/Model/FeatureCollection.cs
+++ b/backend/DefikarteBackend/Model/FeatureCollection.cs
@@ -10,6 +10,7 @@ namespace DefikarteBackend.Model
     }
 
     public class FeatureCollection<TFeature>
+        where TFeature : Feature
     {
         public string Type { get; set; } = "FeatureCollection";
 

--- a/backend/DefikarteBackend/Model/MapTilerFeature.cs
+++ b/backend/DefikarteBackend/Model/MapTilerFeature.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace DefikarteBackend.Model
+{
+    public class MapTilerFeature : Feature
+    {
+        [JsonProperty("place_name")]
+        public string PlaceName { get; set; } = string.Empty;
+
+        [JsonProperty("text")]
+        public string Text { get; set; } = string.Empty;
+
+        [JsonIgnore]
+        public override Dictionary<string, string> Properties { get; set; } = [];
+
+        [JsonProperty("properties")]
+        public Dictionary<string, object> MaptilerProperties { get; set; } = [];
+
+    }
+}

--- a/backend/DefikarteBackend/Model/SwisstopoFeature.cs
+++ b/backend/DefikarteBackend/Model/SwisstopoFeature.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DefikarteBackend.Model
+{
+    public class SwisstopoFeature : Feature
+    {
+        [JsonIgnore]
+        public override Dictionary<string, string> Properties { get; set; } = [];
+
+        [JsonProperty("properties")]
+        public Dictionary<string, JToken> SwisstopoProperties { get; set; } = [];
+    }
+}

--- a/backend/DefikarteBackend/Program.cs
+++ b/backend/DefikarteBackend/Program.cs
@@ -79,7 +79,7 @@ internal class Program
                 services.AddTransient<IValidator<DefibrillatorRequestV2>, DefibrillatorRequestValidatorV2>();
                 services.AddTransient<IValidator<FeatureCollection>, FeatureCollectionValidator>();
 
-                services.AddTransient<IAddressSearchService, AddressSearchService>();
+                services.AddTransient<IAddressSearchService, MaptilerAddressSearchService>();
 
                 services.AddSingleton<IGeofenceService, GeofenceService>();
                 RegisterNtsGeometryServices(services);

--- a/backend/DefikarteBackend/Program.cs
+++ b/backend/DefikarteBackend/Program.cs
@@ -79,7 +79,7 @@ internal class Program
                 services.AddTransient<IValidator<DefibrillatorRequestV2>, DefibrillatorRequestValidatorV2>();
                 services.AddTransient<IValidator<FeatureCollection>, FeatureCollectionValidator>();
 
-                services.AddTransient<IAddressSearchService, MaptilerAddressSearchService>();
+                services.AddTransient<IAddressSearchService, SwisstopoAddressSearchService>();
 
                 services.AddSingleton<IGeofenceService, GeofenceService>();
                 RegisterNtsGeometryServices(services);

--- a/backend/DefikarteBackend/Services/MaptilerAddressSearchService.cs
+++ b/backend/DefikarteBackend/Services/MaptilerAddressSearchService.cs
@@ -1,0 +1,99 @@
+﻿using DefikarteBackend.Interfaces;
+using DefikarteBackend.Model;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace DefikarteBackend.Services
+{
+    public class MaptilerAddressSearchService : IAddressSearchService
+    {
+        private static readonly HttpClient _httpClient = new();
+        private readonly IServiceConfiguration _configuration;
+        private readonly ILogger<MaptilerAddressSearchService> _logger;
+
+        public MaptilerAddressSearchService(IServiceConfiguration configuration, ILogger<MaptilerAddressSearchService> logger)
+        {
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public async Task<FeatureCollection?> SearchAddressAsync(string searchText)
+        {
+            var query = new Dictionary<string, string>
+            {
+                { "types", "region,municipality,municipal_district,locality,place,address,road,poi" },
+                { "country", "ch" },
+                { "limit", "10" },
+                { "key",  _configuration.MaptilerApiKey }
+            };
+
+            try
+            {
+                var uriBuilder = new UriBuilder($"https://api.maptiler.com/geocoding/{searchText}.json")
+                {
+                    Query = await new FormUrlEncodedContent(query).ReadAsStringAsync().ConfigureAwait(false)
+                };
+
+                var url = uriBuilder.ToString();
+                var response = await _httpClient.GetAsync(url).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var featureCollection = JsonConvert.DeserializeObject<FeatureCollection<MapTilerFeature>>(jsonString);
+                    if (featureCollection == null)
+                    {
+                        return null;
+                    }
+
+                    // place_name examples
+                    // poi: Medienpark, Flurstrasse 53, 8048 Zürich, Schweiz/Suisse/Svizzera/Svizra
+                    // address: Flurstrasse 55, 8048 Zürich, Schweiz/Suisse/Svizzera/Svizra
+                    foreach (var feature in featureCollection.Features)
+                    {
+                        if (!string.IsNullOrEmpty(feature.PlaceName))
+                        {
+                            var values = CleanPlaceNameContent(feature.PlaceName);
+                            feature.MaptilerProperties["addressPrimary"] = values != null && values.Count > 0 ? values[0] : string.Empty;
+                            feature.MaptilerProperties["addressSecondary"] = values != null && values.Count > 1 ? values[1] : string.Empty;
+                        }
+                    }
+
+                    return ConvertToFeatureCollection(featureCollection);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error searching address.");
+            }
+
+            return new FeatureCollection { Type = "FeatureCollection", Features = [] };
+        }
+
+        private static List<string>? CleanPlaceNameContent(string placeName)
+        {
+            if (string.IsNullOrEmpty(placeName))
+            {
+                return null;
+            }
+
+            var parts = placeName
+                .Split(",")
+                .Select(part => part.Trim())
+                .Where(part => !string.IsNullOrWhiteSpace(part) && !part.Contains("Schweiz/Suisse/Svizzera/Svizra"))
+                .ToList();
+
+            int index = parts.Count / 2;
+            string firstPart = string.Join(", ", parts.Take(index));
+            string secondPart = string.Join(", ", parts.Skip(index));
+            return [firstPart, secondPart];
+        }
+
+        private static FeatureCollection ConvertToFeatureCollection(FeatureCollection<MapTilerFeature> source)
+        {
+            return new FeatureCollection
+            {
+                Features = source.Features.Select(f => (Feature)f).ToList(),
+            };
+        }
+    }
+}

--- a/backend/DefikarteBackend/Services/SwisstopoAddressSearchService.cs
+++ b/backend/DefikarteBackend/Services/SwisstopoAddressSearchService.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace DefikarteBackend.Services
 {
-    public class AddressSearchService : IAddressSearchService
+    public class SwisstopoAddressSearchService : IAddressSearchService
     {
         private static readonly string ICON_TAG = "<i>";
         private static readonly string ICON_TAG_END = "</i>";
@@ -15,9 +15,9 @@ namespace DefikarteBackend.Services
         private static readonly List<string> TAG_LIST = [ICON_TAG, ICON_TAG_END, BOLD_TAG, BOLD_TAG_END];
 
         private readonly IServiceConfiguration _configuration;
-        private readonly ILogger<AddressSearchService> _logger;
+        private readonly ILogger<SwisstopoAddressSearchService> _logger;
 
-        public AddressSearchService(IServiceConfiguration configuration, ILogger<AddressSearchService> logger)
+        public SwisstopoAddressSearchService(IServiceConfiguration configuration, ILogger<SwisstopoAddressSearchService> logger)
         {
             _configuration = configuration;
             _logger = logger;

--- a/backend/DefikarteBackend/Services/SwisstopoAddressSearchService.cs
+++ b/backend/DefikarteBackend/Services/SwisstopoAddressSearchService.cs
@@ -55,11 +55,11 @@ namespace DefikarteBackend.Services
 
                     foreach (var feature in featureCollection.Features)
                     {
-                        if (feature.Properties.TryGetValue("label", out var label) && !string.IsNullOrEmpty(label))
+                        if (feature.SwisstopoProperties.TryGetValue("label", out var label) && !string.IsNullOrEmpty(label?.ToString()))
                         {
-                            var values = CleanLabelContent(label);
-                            feature.Properties["addressPrimary"] = values != null && values.Count > 0 ? values[0] : string.Empty;
-                            feature.Properties["addressSecondary"] = values != null && values.Count > 1 ? values[1] : string.Empty;
+                            var values = CleanLabelContent(label.ToString());
+                            feature.SwisstopoProperties["addressPrimary"] = values != null && values.Count > 0 ? values[0] : string.Empty;
+                            feature.SwisstopoProperties["addressSecondary"] = values != null && values.Count > 1 ? values[1] : string.Empty;
                         }
                     }
 

--- a/backend/DefikarteBackend/Services/SwisstopoAddressSearchService.cs
+++ b/backend/DefikarteBackend/Services/SwisstopoAddressSearchService.cs
@@ -47,7 +47,7 @@ namespace DefikarteBackend.Services
                 if (response.IsSuccessStatusCode)
                 {
                     var jsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var featureCollection = JsonConvert.DeserializeObject<FeatureCollection>(jsonString);
+                    var featureCollection = JsonConvert.DeserializeObject<FeatureCollection<SwisstopoFeature>>(jsonString);
                     if (featureCollection == null)
                     {
                         return null;
@@ -63,7 +63,7 @@ namespace DefikarteBackend.Services
                         }
                     }
 
-                    return featureCollection;
+                    return ConvertToFeatureCollection(featureCollection);
                 }
             }
             catch (Exception ex)
@@ -92,6 +92,14 @@ namespace DefikarteBackend.Services
                 .Skip(index + 1)
                 .Where(part => !TAG_LIST.Contains(part))
                 .ToList();
+        }
+
+        private static FeatureCollection ConvertToFeatureCollection(FeatureCollection<SwisstopoFeature> source)
+        {
+            return new FeatureCollection
+            {
+                Features = source.Features.Select(f => (Feature)f).ToList(),
+            };
         }
     }
 }


### PR DESCRIPTION
Make the json-parser more resilient in accepting all kind of structure in the features.properites object. This resolves the json-parsing exceptions with some searches that contain complex objects (i.e. "links") in the properties.